### PR TITLE
Rewrite of TiledH5PY

### DIFF
--- a/bigimtools/adapters.py
+++ b/bigimtools/adapters.py
@@ -39,13 +39,14 @@ class TiledH5PY:
 
     def __setitem__(self, item, value):
         self.content["_".join(str(i) for i in check_pair(item))] = value
-    
+
     def __len__(self):
-        return(len(self.content))
-    
+        return len(self.content)
+
     def keys(self):
         def _key_to_tuple(key):
             return tuple(int(string) for string in key.split("_"))
+
         for key in self.content.keys():
             yield _key_to_tuple(key)
 
@@ -55,12 +56,13 @@ class TiledH5PY:
     def items(self):
         for k in self.keys():
             yield (k, self[k])
-    
+
     def get(self, item, value=None):
         try:
             return self[item]
         except KeyError:
             return value
+
 
 class TiledFolder:
     """A tile ndarray maps all data to a

--- a/bigimtools/adapters.py
+++ b/bigimtools/adapters.py
@@ -35,11 +35,32 @@ class TiledH5PY:
         self.content = content
 
     def __getitem__(self, item):
-        return self.content["_".join(check_pair(item))]
+        return self.content["_".join(str(i) for i in check_pair(item))]
 
     def __setitem__(self, item, value):
-        self.content["_".join(check_pair(item))] = value
+        self.content["_".join(str(i) for i in check_pair(item))] = value
+    
+    def __len__(self):
+        return(len(self.content))
+    
+    def keys(self):
+        def _key_to_tuple(key):
+            return tuple(int(string) for string in key.split("_"))
+        for key in self.content.keys():
+            yield _key_to_tuple(key)
 
+    def values(self):
+        return self.content.values()
+
+    def items(self):
+        for k in self.keys():
+            yield (k, self[k])
+    
+    def get(self, item, value=None):
+        try:
+            return self[item]
+        except KeyError:
+            return value
 
 class TiledFolder:
     """A tile ndarray maps all data to a

--- a/bigimtools/tiler.py
+++ b/bigimtools/tiler.py
@@ -191,6 +191,8 @@ def equalize_tiles(
     ndx0s, ndx1s = zip(*tiles.keys())
 
     for ndx0, ndx1 in scan_func((max(ndx0s), max(ndx1s)), init):
+        ndx0 = int(ndx0)
+        ndx1 = int(ndx1)
         tile = tiles[(ndx0, ndx1)]
 
         corr1 = est_func(


### PR DESCRIPTION
First attempt at modifying the HDF5 tile adapter towards a tile dict suitable for `tiler.equalize_tiles()` and `tiler.join_tiles()` as input. Probably lacking some methods to be a full blown dict, but it successfully allows  running
```python
with h5py.File(path, 'r') as f:
    tiles = TiledH5PY(f)
    corrections = tiler.equalize_tiles(tiles, overlap,init)
    im = tiler.join_tiles(tiles, overlap, corrections)
```
Although some weird behavior happens when calling `tiler.equalize_tiles()`: the indices generated in

`tiler.py`
```python
    ndx0s, ndx1s = zip(*tiles.keys())
```
aren't recognized later as a tuple of ints, with a raise of `ValueError: (1, 2) is not a valid item, should be (int, int).`
This is solved by casting them as ints, still a weird error.
