### PR TITLE
Experimental fixes for DZI generation and overlap matrix contrast correction

### DIFF
--- a/bigimtools/dzi.py
+++ b/bigimtools/dzi.py
@@ -125,10 +125,16 @@ def save_image(arr, path, fmt, in_range, jpeg_image_quality=0.8):
         str(path) + "." + ("jpg" if fmt is ImageFormat.JPEG8 else "png")
     )
 
+    # Write empty array as a black pixel
+    if len(arr) == 0:
+        arr = np.array([[0]])
+
     if fmt is ImageFormat.JPEG8:
-        skimage.io.imsave(path, arr, quality=jpeg_image_quality)
+        skimage.io.imsave(
+            path, arr, quality=jpeg_image_quality, check_contrast=False
+        )
     else:
-        skimage.io.imsave(path, arr)
+        skimage.io.imsave(path, arr, check_contrast=False)
 
 
 @dataclass(frozen=True)

--- a/bigimtools/testsuite/test_tiler.py
+++ b/bigimtools/testsuite/test_tiler.py
@@ -98,3 +98,22 @@ def test_equalize_changed(imcamera, tile_size, overlap, init):
     for ndx0 in (3, 5, 13):
         for ndx1 in (4, 7, 20):
             assert corrections[(ndx0, ndx1)] == 1 / 13.0
+
+
+# Crashes test suite! Beware
+# @pytest.mark.parametrize("tile_size", ((3, 3), (5, 10), (10, 10)))
+# @pytest.mark.parametrize("overlap", ((5, 5), (3, 6), (6, 3)))
+# @pytest.mark.parametrize("init", ((1, 1), (5, 10), (10, 5)))
+# def test_ov_equalize_changed(imcamera, tile_size, overlap, init):
+
+#     tiles = dict(tiler.split_into_tiles(imcamera, tile_size, overlap))
+
+#     for ndx0 in (3, 5, 13):
+#         for ndx1 in (4, 7, 20):
+#             tiles[(ndx0, ndx1)] = tiles[(ndx0, ndx1)] * 13.0
+#     overlap_mat = tiler.overlap_matrix(tiles, overlap)
+#     corrections = tiler.coef_matrix_brute_force(overlap_mat)
+#     print(corrections)
+#     for ndx0 in (3, 5, 13):
+#         for ndx1 in (4, 7, 20):
+#             assert corrections[(ndx0, ndx1)] == 1 / 13.0

--- a/bigimtools/tiler.py
+++ b/bigimtools/tiler.py
@@ -196,7 +196,6 @@ def equalize_tiles(
         ndx0 = int(ndx0)
         ndx1 = int(ndx1)
         tile = tiles[(ndx0, ndx1)]
-        print((ndx0, ndx1))
         corr1 = est_func(
             tile[-ov0:, :],
             tiles.get((ndx0 + 1, ndx1), _NaNArray)[:+ov0, :]


### PR DESCRIPTION
DZI generation is still faulty with real samples. Test added for the new contrast correction results in extremely slow and memory consuming operations which likely crash when running pytest (commented out for safe measure)